### PR TITLE
docs: standardize README title and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # hikearound-cloud-functions
 
-[![CI](https://github.com/hikearound/hikearound-cloud-functions/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/hikearound/hikearound-cloud-functions/actions/workflows/ci.yml)
-[![Node.js](https://img.shields.io/badge/Node.js-14-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![Firebase](https://img.shields.io/badge/Firebase-Cloud%20Functions-FFCA28?logo=firebase&logoColor=white)](https://firebase.google.com/docs/functions)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?logo=opensourceinitiative&logoColor=white)](LICENSE)
+[![CI](https://github.com/hikearound/hikearound-cloud-functions/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/hikearound/hikearound-cloud-functions/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/hikearound/hikearound-cloud-functions)](LICENSE)
 
 Serverless functions for Hikearound's web and iOS clients, built with Firebase Cloud Functions.
 


### PR DESCRIPTION
## Summary

- normalize the README H1 to the exact lowercase repository slug
- standardize the top badge block around provider-default, authoritative project signals
- leave all README body copy unchanged

## Why

This applies the approved fleet convention based on `readwise-reader-import` and the external repository sample. Decorative implementation badges are omitted; package compatibility, documentation, release, coverage, CI, and public-license badges are retained only when backed by a live source.

## Impact

Documentation only. No source, dependency, workflow, settings, or deployment behavior changes.

## Validation

- changed path is exactly `README.md`
- README body is byte-for-byte unchanged
- `git diff --check`
- badge and workflow targets verified against current repository state
